### PR TITLE
Rework lease system to use OnUpdate Hook

### DIFF
--- a/Gates/Lease.cs
+++ b/Gates/Lease.cs
@@ -37,6 +37,13 @@ namespace KitchenPlateupAP
             if (!ArchipelagoConnectionManager.ConnectionSuccessful || ArchipelagoConnectionManager.Session == null)
                 return;
 
+            if (!Mod.SlotDataLoaded)
+            {
+                ClearGate(HasSingleton<SDay>() ? GetSingleton<SDay>().Day : 0);
+                forceRefresh = false;
+                return;
+            }
+
             if (!HasSingleton<SKitchenMarker>() || !HasSingleton<SIsNightTime>())
                 return;
 
@@ -52,12 +59,74 @@ namespace KitchenPlateupAP
             if (currentDay < 1)
                 return;
 
+            LastStatus = BuildStatus(currentDay);
+            SetStartDayWarning(LastStatus.IsGateActive);
+            forceRefresh = false;
+        }
+
+        /// <summary>
+        /// Called from the StartNewDay Harmony boundary. Recompute against the live
+        /// AP receipt pool so a received lease clears an already-displayed gate
+        /// before the next SimulationSystemGroup update.
+        /// </summary>
+        public static bool ShouldBlockStartDay(int currentDay)
+        {
+            if (!Mod.SlotDataLoaded || !Mod.DayLeasesEnabled || Mod.DebugLeaseGateDisabled)
+                return false;
+
+            if (!ArchipelagoConnectionManager.ConnectionSuccessful
+                || ArchipelagoConnectionManager.Session == null
+                || ArchipelagoConnectionManager.Session.Items == null)
+                return false;
+
+            if (currentDay < 1)
+                return false;
+
+            LastStatus = BuildStatus(currentDay);
+            forceRefresh = false;
+            return LastStatus.IsGateActive;
+        }
+
+        /// <summary>
+        /// Supplies the start-day warning view with lease-specific copy while the
+        /// lease requirement is active. This uses the live receipt pool for the
+        /// same immediate-refresh behaviour as the start-day boundary.
+        /// </summary>
+        public static bool TryGetActiveLeaseMessage(out string title, out string description)
+        {
+            title = null;
+            description = null;
+
+            if (!Mod.SlotDataLoaded || !Mod.DayLeasesEnabled || Mod.DebugLeaseGateDisabled
+                || !ArchipelagoConnectionManager.ConnectionSuccessful
+                || ArchipelagoConnectionManager.Session == null
+                || ArchipelagoConnectionManager.Session.Items == null
+                || !LastStatus.IsValid
+                || !LastStatus.IsPrepPhase)
+                return false;
+
+            LastStatus = BuildStatus(LastStatus.CurrentDay);
+            forceRefresh = false;
+            if (!LastStatus.IsGateActive)
+                return false;
+
+            string leaseName = Mod.DayLeaseMode == 1
+                ? (LastStatus.CurrentDay > 15 && Mod.OvertimeDays > 0 ? "Overtime Day Lease" : "Dish Day Lease")
+                : "Day Lease";
+
+            title = leaseName + " required";
+            description = $"Receive {leaseName} from Archipelago ({LastStatus.Owned}/{LastStatus.Required} received).";
+            return true;
+        }
+
+        private static CachedLeaseInfo BuildStatus(int currentDay)
+        {
             int goal = Mod.Goal;
             int interval = Math.Max(1, Math.Min(30, Mod.DayLeaseInterval));
             int leaseMode = Mod.DayLeaseMode;    // 0 = global, 1 = dish_specific
             int overtimeDays = Mod.OvertimeDays;
             int highestDay = (goal == 1 || goal == 2) ? Mod.HighestOverallDayReached : 0;
-            int timesFranchised = Mod.Instance?.TimesFranchised ?? 1;
+            int timesFranchised = Mod.Instance?.TimesFranchised ?? 0;
 
             var allItems = ArchipelagoConnectionManager.Session.Items.AllItemsReceived;
 
@@ -65,62 +134,38 @@ namespace KitchenPlateupAP
             int leaseCount;
             int requiredLeases;
 
-            // ADD LOGGING HERE
-            Mod.Logger.LogInfo($"[LeaseGate] Day={currentDay}, Goal={goal}, Mode={leaseMode}, Interval={interval}");
-
-            // ── Branch: goal 2 + dish_specific — never gated ─────────────────
-            if (leaseMode == 1 && goal == 2)
-            {
-                gateActive = false;
-                leaseCount = 0;
-                requiredLeases = 0;
-                Mod.Logger.LogInfo($"[LeaseGate] Goal 2 + dish_specific: gate disabled");
-            }
             // ── Branch: global mode — "Day Lease" (ID 15) gates all days ─────
-            else if (leaseMode == 0)
+            if (leaseMode == 0)
             {
                 leaseCount = allItems.Count(item => (int)item.ItemId == 15);
                 requiredLeases = ComputeRequiredLeases(goal, currentDay, highestDay, timesFranchised, interval);
                 gateActive = requiredLeases > 0 && leaseCount < requiredLeases;
-                Mod.Logger.LogInfo($"[LeaseGate] Global mode: owned={leaseCount}, required={requiredLeases}, gateActive={gateActive}");
             }
-            // ── Branch: dish_specific, goals 0/1 ─────────────────────────────
+            // ── Branch: dish_specific — the active dish's lease gates its run ─
             else
             {
                 if (currentDay <= 15)
                 {
-                    // Per-dish lease IDs from ProgressionMapping.dishLeaseItemIds
+                    // Per-dish lease IDs from ProgressionMapping.dishLeaseItemIds.
+                    // This also applies to goal 2; dish_lease_scope determines
+                    // whether the current dish participates in that goal's gate.
                     gateActive = false;
                     leaseCount = 0;
                     requiredLeases = 0;
 
                     string currentDishName = Mod.Instance?.GetDishName(Mod.Instance.ActiveDishId);
-                    Mod.Logger.LogInfo($"[LeaseGate] Dish-specific mode: currentDish='{currentDishName}' (ID={Mod.Instance?.ActiveDishId})");
 
                     if (!string.IsNullOrWhiteSpace(currentDishName) && currentDishName != "Unknown"
                         && ProgressionMapping.dishLeaseItemIds.TryGetValue(currentDishName, out int leaseItemId))
                     {
-                        // dish_lease_scope: 0=all_dishes (gate any known dish), 1=goal_count_only (gate only selected dishes)
-                        bool dishIsInScope = Mod.DishLeaseScope == 0
-                            || Mod.SelectedDishes.Contains(currentDishName, StringComparer.OrdinalIgnoreCase);
-
-                        Mod.Logger.LogInfo($"[LeaseGate] Dish '{currentDishName}' leaseItemId={leaseItemId}, inScope={dishIsInScope}");
+                        bool dishIsInScope = IsDishInLeaseScope(goal, currentDishName);
 
                         if (dishIsInScope)
                         {
                             leaseCount = allItems.Count(item => (int)item.ItemId == leaseItemId);
                             requiredLeases = ComputeRequiredLeases(goal, currentDay, highestDay, timesFranchised, interval, true);
                             gateActive = requiredLeases > 0 && leaseCount < requiredLeases;
-                            Mod.Logger.LogInfo($"[LeaseGate] Dish-specific: owned={leaseCount}, required={requiredLeases}, gateActive={gateActive}");
                         }
-                        else
-                        {
-                            Mod.Logger.LogInfo($"[LeaseGate] Dish '{currentDishName}' not in scope; gate disabled");
-                        }
-                    }
-                    else
-                    {
-                        Mod.Logger.LogWarning($"[LeaseGate] Could not get dish lease ID for '{currentDishName}'; gate disabled");
                     }
                 }
                 else
@@ -151,26 +196,21 @@ namespace KitchenPlateupAP
                     int nextThreshold = (requiredLeases + 1) * interval;
                     daysUntilNext = Math.Max(0, nextThreshold - overtimeHighest);
                 }
-                else if (goal == 0)
-                {
-                    int nextRequiredDay = (requiredLeases + 1) * interval;
-                    daysUntilNext = Math.Max(0, nextRequiredDay - currentDay);
-                }
                 else
                 {
-                    int nextThreshold = (requiredLeases + 1) * interval;
-                    daysUntilNext = Math.Max(0, nextThreshold - highestDay);
+                    int leaseDay = goal == 0 && leaseMode == 0
+                        ? Math.Max(0, timesFranchised) * 15 + currentDay
+                        : goal == 1
+                            ? Math.Max(currentDay, highestDay + 1)
+                            : currentDay;
+                    int nextRequiredDay = Mod.DayLeasesProgressive
+                        ? requiredLeases * interval + 1
+                        : (requiredLeases + 1) * interval + 1;
+                    daysUntilNext = Math.Max(0, nextRequiredDay - leaseDay);
                 }
             }
 
-            if (HasSingleton<SStartDayWarnings>())
-            {
-                var warnings = GetSingleton<SStartDayWarnings>();
-                warnings.SellingRequiredAppliance = gateActive ? WarningLevel.Error : WarningLevel.Safe;
-                SetSingleton(warnings);
-            }
-
-            LastStatus = new CachedLeaseInfo
+            return new CachedLeaseInfo
             {
                 IsValid = true,
                 IsPrepPhase = true,
@@ -180,18 +220,21 @@ namespace KitchenPlateupAP
                 IsGateActive = gateActive,
                 DaysUntilNext = daysUntilNext
             };
+        }
 
-            forceRefresh = false;
+        private void SetStartDayWarning(bool gateActive)
+        {
+            if (!HasSingleton<SStartDayWarnings>())
+                return;
+
+            var warnings = GetSingleton<SStartDayWarnings>();
+            warnings.SellingRequiredAppliance = gateActive ? WarningLevel.Error : WarningLevel.Safe;
+            SetSingleton(warnings);
         }
 
         private void ClearGate(int currentDay)
         {
-            if (HasSingleton<SStartDayWarnings>())
-            {
-                var warnings = GetSingleton<SStartDayWarnings>();
-                warnings.SellingRequiredAppliance = WarningLevel.Safe;
-                SetSingleton(warnings);
-            }
+            SetStartDayWarning(false);
 
             LastStatus = new CachedLeaseInfo
             {
@@ -207,14 +250,14 @@ namespace KitchenPlateupAP
 
         /// <summary>
         /// Required leases for global mode or dish-specific days 1–15.
-        /// Goal 0 / global: segment-based within the 15-day franchise cycle
-        ///   (multiple leases possible since item ID 15 can appear multiple times).
-        /// Goal 0 / dish-specific: interval-based scaling — 0 for the free first interval,
-        ///   then 1 lease per subsequent interval (scales with day progression).
-        /// Goal 1: floor(highestDayReached / interval) high-water mark —
-        ///   first <paramref name="interval"/> days always free.
-        /// Goal 2: floor(currentDay / interval) per-run gate — resets each dish run
-        ///   since each dish starts from day 1 independently.
+        /// Goal 0 / global: treats franchise days as one global sequence.
+        /// Goal 0 / dish-specific: interval-based scaling — standard leases make
+        ///   the first interval free, while progressive leases include it.
+        /// Goal 1: uses the next AP progress day, preserving high-water progress
+        ///   across failed or restarted restaurants.
+        /// Goal 2: an active dish's current-run day determines its requirement;
+        ///   standard leases use floor((day - 1) / interval), while progressive
+        ///   leases use ceil(day / interval).
         /// </summary>
         private static int ComputeRequiredLeases(
             int goal,
@@ -232,42 +275,52 @@ namespace KitchenPlateupAP
 
                 if (isDishSpecific)
                 {
-                    // For dish-specific mode: scale with intervals
-                    // Day 1-interval: 0 leases, Day (interval+1)-(2*interval): 1 lease, etc.
-                    if (currentDay <= interval)
-                        return 0;
-                    
-                    raw = (currentDay - 1) / interval;
+                    raw = ComputeLeaseBlocksForDay(currentDay, interval);
                 }
                 else
                 {
-                    // Global mode: accumulate across franchises
-                    int segmentsPerFranchise = (int)Math.Ceiling(15.0 / interval);
-                    int baseOffset = segmentsPerFranchise * Math.Max(0, timesFranchised - 1);
-                    int withinRun = Math.Min(segmentsPerFranchise - 1, (currentDay - 1) / interval);
-
-                    if (timesFranchised == 1 && currentDay <= interval)
-                        return 0;
-
-                    raw = baseOffset + withinRun;
+                    int globalDay = Math.Max(0, timesFranchised) * 15 + currentDay;
+                    raw = ComputeLeaseBlocksForDay(globalDay, interval);
                 }
             }
-            else if (goal == 2)
+            else if (goal == 1)
             {
-                // Each dish run is independent and starts at day 1, so gate on the
-                // current run's day rather than the all-time high-water mark.
-                // This prevents runs on a new dish from being immediately blocked
-                // because a previous dish already reached a high day count.
-                raw = currentDay / interval;
+                int effectiveNextDay = Math.Max(currentDay, highestDayReached + 1);
+                raw = ComputeLeaseBlocksForDay(effectiveNextDay, interval);
             }
             else
             {
-                // Goal 1: accumulate total days globally, so high-water mark is correct.
-                raw = highestDayReached / interval;
+                // Goal 2 gates the active dish's current run.
+                raw = ComputeLeaseBlocksForDay(currentDay, interval);
             }
 
-            // Never require more leases than exist in the AP pool
-            return Math.Min(raw, Mod.MaxDayLeases);
+            // Global and dish-specific pools report separate maximum counts.
+            int maximumAvailable = isDishSpecific ? Mod.MaxDishDayLeases : Mod.MaxDayLeases;
+            return Math.Min(raw, maximumAvailable);
+        }
+
+        private static int ComputeLeaseBlocksForDay(int day, int interval)
+        {
+            if (day < 1)
+                return 0;
+
+            // Progressive: ceil(day / interval), so even the first block needs a lease.
+            // Standard: floor((day - 1) / interval), so the first block is free.
+            return Mod.DayLeasesProgressive
+                ? (day + interval - 1) / interval
+                : (day - 1) / interval;
+        }
+
+        private static bool IsDishInLeaseScope(int goal, string dishName)
+        {
+            // goal_count_only applies only to goal 2. Goals 0 and 1 always give
+            // every participating dish its own lease set.
+            if (goal != 2 || Mod.DishLeaseScope == 0)
+                return true;
+
+            return Mod.SelectedDishes
+                .Take(Math.Max(0, Mod.DishGoalCount))
+                .Contains(dishName, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/Mod.cs
+++ b/Mod.cs
@@ -108,6 +108,8 @@ namespace KitchenPlateupAP
         private static int dayLeaseMode = 0;            // 0 = global, 1 = dish_specific
         private static int dishLeaseScope = 0;          // 0 = all_dishes, 1 = goal_count_only (only when goal == 2)                                                      // near the other lease fields (~line 106)
         private static int maxDayLeases = int.MaxValue;  // total Day Lease items in the AP pool
+        private static int maxDishDayLeases = int.MaxValue; // copies of each dish-specific Day Lease in the AP pool
+        private static bool dayLeasesProgressive = false;
         private static bool debugLeaseGateDisabled = false;
         public static bool DebugLeaseGateDisabled => debugLeaseGateDisabled;
         private static int overtimeDays = 0;            // overtime_days: days > 15 that overtime leases cover (0 = none)
@@ -537,9 +539,22 @@ namespace KitchenPlateupAP
                 return; // Not connected
 
             var slotData = ArchipelagoConnectionManager.SlotData;
+            SlotDataLoaded = false;
 
             if (slotData != null)
             {
+                // A client can reconnect to a different slot without restarting the
+                // game. Reset lease-derived values before parsing so omitted fields
+                // cannot retain requirements or caps from the previous seed.
+                dayLeasesEnabled = true;
+                dayLeaseMode = 0;
+                dishLeaseScope = 0;
+                maxDayLeases = int.MaxValue;
+                maxDishDayLeases = int.MaxValue;
+                dayLeasesProgressive = false;
+                overtimeDays = 0;
+                dayLeaseInterval = 5;
+
                 Logger.LogInfo($"[PlateupAP] Full Slot Data: {JsonConvert.SerializeObject(slotData, Formatting.Indented)}");
 
                 if (ArchipelagoConnectionManager.SlotData.TryGetValue("starting_cards", out object rawStartingCards))
@@ -715,6 +730,30 @@ namespace KitchenPlateupAP
                     maxDayLeases = Mathf.Max(0, Convert.ToInt32(rawLeaseCount));
                     Logger.LogInfo($"[PlateupAP] Max Day Leases in pool: {maxDayLeases}");
                 }
+                else
+                {
+                    maxDayLeases = int.MaxValue;
+                }
+
+                if (slotData.TryGetValue("dish_lease_count", out object rawDishLeaseCount))
+                {
+                    maxDishDayLeases = Mathf.Max(0, Convert.ToInt32(rawDishLeaseCount));
+                    Logger.LogInfo($"[PlateupAP] Max Dish Day Leases per dish: {maxDishDayLeases}");
+                }
+                else
+                {
+                    maxDishDayLeases = int.MaxValue;
+                }
+
+                if (slotData.TryGetValue("day_leases_progressive", out object rawProgressiveLeases))
+                {
+                    dayLeasesProgressive = Convert.ToBoolean(rawProgressiveLeases);
+                    Logger.LogInfo($"[PlateupAP] Progressive Day Leases: {dayLeasesProgressive}");
+                }
+                else
+                {
+                    dayLeasesProgressive = false;
+                }
 
                 if (slotData.TryGetValue("overtime_days", out object rawOvertimeDays))
                 {
@@ -787,8 +826,9 @@ namespace KitchenPlateupAP
                 {
                     dayLeaseInterval = Mathf.Clamp(Convert.ToInt32(rawLeaseInterval), 1, 30);
                     Logger.LogInfo($"[PlateupAP] Day Lease Interval set to: {dayLeaseInterval}");
-                    KitchenPlateupAP.LeaseRequirementSystem.TriggerRefresh();
                 }
+
+                KitchenPlateupAP.LeaseRequirementSystem.TriggerRefresh();
 
                 if (slotData.TryGetValue("player_speed_upgrade_count", out object rawPlayerSpeedCount))
                 {
@@ -796,7 +836,6 @@ namespace KitchenPlateupAP
                     playerSpeedUpgradeCount = value;
                     Logger.LogInfo($"[PlateupAP] Player Speed Upgrade Count: {playerSpeedUpgradeCount}");
                     ApplyPlayerSpeedConfig();
-                    SlotDataLoaded = true;
                 }
                 else
                 {
@@ -1001,6 +1040,7 @@ namespace KitchenPlateupAP
                 BlueprintCheckManager.LoadState(PersistenceManager.LoadBlueprintCheckState(currentIdentity));
                 BlueprintCheckManager.ScoutAllLocations();
                 Logger.LogInfo($"[BlueprintChecks] Enabled={BlueprintCheckManager.IsEnabled}, Count={BlueprintCheckManager.CheckIds.Count}");
+                SlotDataLoaded = true;
             }
 
             if (selectedDishes.Count == 0)
@@ -4180,6 +4220,8 @@ namespace KitchenPlateupAP
         internal static int HighestOverallDayReached => highestOverallDayReached;
         internal static int DayLeaseInterval => dayLeaseInterval;
         public static int MaxDayLeases => maxDayLeases;
+        public static int MaxDishDayLeases => maxDishDayLeases;
+        internal static bool DayLeasesProgressive => dayLeasesProgressive;
         internal int TimesFranchised => timesFranchised;
         internal static bool DayLeasesEnabled => dayLeasesEnabled;
         internal static int DayLeaseMode => dayLeaseMode;

--- a/Patches/LeaseStartDayPatch.cs
+++ b/Patches/LeaseStartDayPatch.cs
@@ -1,0 +1,83 @@
+using HarmonyLib;
+using Kitchen;
+using TMPro;
+
+namespace KitchenPlateupAP.Patches
+{
+    /// <summary>
+    /// StartNewDay.OnUpdate is the authoritative transition from night/prep into
+    /// the next day. Vanilla does not inspect SellingRequiredAppliance, so the
+    /// lease gate must intercept this action rather than only populate the UI
+    /// warning component.
+    /// </summary>
+    [HarmonyPatch(typeof(StartNewDay), "OnUpdate")]
+    internal static class LeaseStartDayPatch
+    {
+        private static bool wasBlocking;
+        private static int lastDay = -1;
+        private static int lastOwned = -1;
+        private static int lastRequired = -1;
+
+        [HarmonyPrefix]
+        private static bool Prefix(StartNewDay __instance)
+        {
+            if (!__instance.HasSingleton<SDay>())
+                return true;
+
+            int currentDay = __instance.GetSingleton<SDay>().Day;
+            bool isBlocking = LeaseRequirementSystem.ShouldBlockStartDay(currentDay);
+            var status = LeaseRequirementSystem.LastStatus;
+
+            if (isBlocking
+                && (!wasBlocking || currentDay != lastDay
+                    || status.Owned != lastOwned || status.Required != lastRequired))
+            {
+                Mod.Logger.LogWarning(
+                    $"[LeaseGate] Blocking day {currentDay}: owned={status.Owned}, required={status.Required}, goal={Mod.Goal}, mode={Mod.DayLeaseMode}, progressive={Mod.DayLeasesProgressive}.");
+            }
+            else if (!isBlocking && wasBlocking)
+            {
+                Mod.Logger.LogInfo(
+                    $"[LeaseGate] Cleared for day {currentDay}: owned={status.Owned}, required={status.Required}, goal={Mod.Goal}, mode={Mod.DayLeaseMode}, progressive={Mod.DayLeasesProgressive}; start-day transition restored.");
+            }
+
+            wasBlocking = isBlocking;
+            lastDay = currentDay;
+            lastOwned = status.Owned;
+            lastRequired = status.Required;
+
+            return !isBlocking;
+        }
+    }
+
+    /// <summary>
+    /// Lease.cs reuses vanilla's existing warning entry to request a start-day
+    /// warning view. Replace only that active lease warning's localised text;
+    /// every other vanilla warning retains its normal localisation.
+    /// </summary>
+    [HarmonyPatch(typeof(StartDayWarningView), "UpdateData")]
+    internal static class LeaseStartDayWarningViewPatch
+    {
+        [HarmonyPostfix]
+        private static void Postfix(StartDayWarningView __instance, StartDayWarningView.ViewData view_data)
+        {
+            if (view_data.Warning != StartDayWarning.SellingRequiredAppliance
+                || !LeaseRequirementSystem.TryGetActiveLeaseMessage(out string title, out string description))
+                return;
+
+            SetText(__instance, "NameLocalisation", title);
+            SetText(__instance, "DescriptionLocalisation", description);
+        }
+
+        private static void SetText(StartDayWarningView view, string localisationField, string text)
+        {
+            var localisation = Traverse.Create(view).Field(localisationField).GetValue<AutoLocal>();
+            if (localisation == null)
+                return;
+
+            var target = Traverse.Create(localisation).Field("_Target").GetValue<TextMeshPro>();
+            if (target != null)
+                target.text = text;
+        }
+    }
+}


### PR DESCRIPTION
Fixes Day Leases not preventing players from starting the next day.

Goal 2 explicitly disabled the client-side gate in dish-specific mode.

- Dish-specific requirements were capped using the global `day_lease_count`. This is zero in seeds containing only per-dish leases, reducing the requirement to zero.
- `SStartDayWarnings.SellingRequiredAppliance` controls the warning UI, but PlateUp does not use that field to prevent `StartNewDay.OnUpdate`.
- Progressive lease configuration was not read from slot data.
- Goal 0 franchise progress was treated as one-based, while timesFranchised is zero-based.
- Goal 1 could lose its high-water requirement after restarting a restaurant.

**Changes**
- Added a Harmony prefix on `StartNewDay.OnUpdate` that blocks the transition while the lease requirement is unmet.
- Recalculates requirements against the current Archipelago item receipt pool when Start Day is attempted.
- Enables dish-specific gating for goal 2.
- Counts only the active dish’s corresponding lease item.
- Uses `dish_lease_count` and `day_lease_count` as separate pool caps.
- Corrected franchise and high-water progress calculations for goals 0 and 1.
- Resets lease-derived settings when connecting to another slot.
- Replaces the misleading “Missing required appliance” warning