### PR TITLE
Fix using Plateup internal IDs instead of Archipelago IDs

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -3617,7 +3617,12 @@ namespace KitchenPlateupAP
                 return;
             }
 
-            int dishCheckID = (DishId * 10000) + currentDishDayCount;
+            if (!ProgressionMapping.dish_id_lookup.TryGetValue(dishName, out int dishID))
+            {
+                Logger.LogWarning($"[Dish Check] No AP dish ID found for '{dishName}'.");
+                return;
+            }
+            int dishCheckID = (dishID * 10000) + currentDishDayCount;
 
             // Skip if already checked (idempotent)
             if (session.Locations.AllLocationsChecked.Contains(dishCheckID))


### PR DESCRIPTION
In commit e42ec8fb there was a change to the `dishCheckID` from `dishID` to `DishId`. The latter is the internal Plateup ID, which is very large and mismatched to the Archipelago server ID.

I have somewhat reverted this to it's previous form, and at least in my (limited) testing dish specific checks are sending again.