### PR TITLE
Fix plate stack unlock targetting 8-plate stack instead of 4

### DIFF
--- a/ProgressionMapping.cs
+++ b/ProgressionMapping.cs
@@ -114,7 +114,7 @@ namespace KitchenPlateupAP
             { 60001, ApplianceReferences.Hob },
             { 60002, ApplianceReferences.Countertop },
             { 60003, ApplianceReferences.SinkNormal },
-            { 60004, ApplianceReferences.PlateStackStarting },
+            { 60004, ApplianceReferences.PlateStack },           // Purchasable eight-plate stack, not the starter stack
             { 60005, ApplianceReferences.BlueprintUpgradeDesk },   // Research Desk
             { 60006, ApplianceReferences.Belt },
             { 60007, ApplianceReferences.Grabber },


### PR DESCRIPTION
I'm actually not sure if this was intended or not, but currently you can't unlock the bigger plate stack. This makes the game way more difficult. I changed the mapping and can confirm the big plate stack now unlocks.