### PR TITLE
Add short popup when receiving or sending checks

### DIFF
--- a/PlateupAP.csproj
+++ b/PlateupAP.csproj
@@ -22,6 +22,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<!-- Archipelago is a runtime dependency and must be deployed with the mod. -->
+		<AdditionalDLLs Include="$(TargetDir)Archipelago.MultiClient.Net.dll" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Compile Remove="UnityProject - PlateupAP\**" />
 		<None Remove="UnityProject - PlateupAP\**" />
 	</ItemGroup>

--- a/UI/Chat.cs
+++ b/UI/Chat.cs
@@ -1,5 +1,6 @@
 ﻿using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
+using Archipelago.MultiClient.Net;
 using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.MessageLog.Parts;
 using Archipelago.MultiClient.Net.Models;
@@ -21,6 +22,7 @@ namespace KitchenPlateupAP
     public class ChatManager : MonoBehaviour
     {
         private static ChatManager Instance;
+        private ArchipelagoSession subscribedSession;
 
         private enum ChatCategory { Normal, System }
 
@@ -136,7 +138,22 @@ namespace KitchenPlateupAP
             if (Instance == null) Instance = this;
             else if (Instance != this) { Destroy(gameObject); return; }
 
+            if (GetComponent<CheckPopupManager>() == null)
+                gameObject.AddComponent<CheckPopupManager>();
+
+            ArchipelagoConnectionManager.Connected += SubscribeEvents;
+            ArchipelagoConnectionManager.Disconnected += OnDisconnected;
             SubscribeEvents();
+        }
+
+        void OnDestroy()
+        {
+            if (Instance != this) return;
+
+            ArchipelagoConnectionManager.Connected -= SubscribeEvents;
+            ArchipelagoConnectionManager.Disconnected -= OnDisconnected;
+            UnsubscribeEvents();
+            Instance = null;
         }
 
         void Update()
@@ -492,21 +509,39 @@ namespace KitchenPlateupAP
         private void SubscribeEvents()
         {
             var session = ArchipelagoConnectionManager.Session;
-            if (session != null && ArchipelagoConnectionManager.ConnectionSuccessful)
+            if (session == null || !ArchipelagoConnectionManager.ConnectionSuccessful || session == subscribedSession)
+                return;
+
+            UnsubscribeEvents();
+            try
             {
-                try
-                {
-                    session.MessageLog.OnMessageReceived += OnStructuredLogMessage;
-                }
-                catch { }
+                session.MessageLog.OnMessageReceived += OnStructuredLogMessage;
+                subscribedSession = session;
             }
+            catch { }
         }
+
+        private void OnDisconnected(string _)
+        {
+            UnsubscribeEvents();
+        }
+
+        private void UnsubscribeEvents()
+        {
+            if (subscribedSession == null) return;
+
+            try { subscribedSession.MessageLog.OnMessageReceived -= OnStructuredLogMessage; }
+            catch { }
+            subscribedSession = null;
+        }
+
         private void OnStructuredLogMessage(APLogMessage msg)
         {
             try
             {
                 var session = ArchipelagoConnectionManager.Session;
                 if (session == null) return;
+                CheckPopupManager.AddFromMessage(msg);
                 var segments = new List<Segment>();
 
                 foreach (var part in msg.Parts)

--- a/UI/CheckPopupManager.cs
+++ b/UI/CheckPopupManager.cs
@@ -1,0 +1,243 @@
+using Archipelago.MultiClient.Net.Helpers;
+using Archipelago.MultiClient.Net.MessageLog.Messages;
+using Archipelago.MultiClient.Net.Models;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityColor = UnityEngine.Color;
+
+namespace KitchenPlateupAP
+{
+    /// <summary>
+    /// Shows short Archipelago item-transfer notifications. Message-log callbacks
+    /// can run off Unity's thread, so popups enter a queue before display.
+    /// </summary>
+    public class CheckPopupManager : MonoBehaviour
+    {
+        private enum TransferDirection
+        {
+            Sent,
+            Received
+        }
+
+        private struct PendingPopup
+        {
+            public TransferDirection Direction;
+            public string ItemName;
+            public string PlayerName;
+        }
+
+        private class ActivePopup
+        {
+            public PendingPopup Data;
+            public float CreatedAt;
+        }
+
+        private const int MaxVisiblePopups = 5;
+        private const float DisplayDuration = 6f;
+        private const float FadeDuration = 1f;
+        private const float PopupWidth = 420f;
+        private const float PopupHeight = 58f;
+        private const float PopupGap = 8f;
+        private const float ScreenMargin = 18f;
+
+        private static readonly object PendingLock = new object();
+        private static readonly Queue<PendingPopup> PendingPopups = new Queue<PendingPopup>();
+
+        private readonly List<ActivePopup> activePopups = new List<ActivePopup>();
+        private GUIStyle messageStyle;
+        private Texture2D backgroundTexture;
+        private Texture2D accentTexture;
+        private Texture2D archipelagoIcon;
+
+        public static void AddFromMessage(LogMessage message)
+        {
+            if (!(message is ItemSendLogMessage transfer) || transfer.Item == null)
+                return;
+
+            if (transfer.IsSenderTheActivePlayer && !transfer.IsReceiverTheActivePlayer)
+            {
+                Enqueue(
+                    TransferDirection.Sent,
+                    GetItemName(transfer.Item),
+                    GetPlayerName(transfer.Receiver));
+            }
+            else if (transfer.IsReceiverTheActivePlayer)
+            {
+                Enqueue(
+                    TransferDirection.Received,
+                    GetItemName(transfer.Item),
+                    GetPlayerName(transfer.Sender));
+            }
+        }
+
+        private static string GetItemName(ItemInfo item)
+        {
+            if (!string.IsNullOrWhiteSpace(item.ItemDisplayName)) return item.ItemDisplayName;
+            if (!string.IsNullOrWhiteSpace(item.ItemName)) return item.ItemName;
+            return "Unknown item";
+        }
+
+        private static string GetPlayerName(PlayerInfo player)
+        {
+            if (player == null) return "Unknown player";
+            if (!string.IsNullOrWhiteSpace(player.Alias)) return player.Alias;
+            if (!string.IsNullOrWhiteSpace(player.Name)) return player.Name;
+            return "Unknown player";
+        }
+
+        private static void Enqueue(TransferDirection direction, string itemName, string playerName)
+        {
+            lock (PendingLock)
+            {
+                PendingPopups.Enqueue(new PendingPopup
+                {
+                    Direction = direction,
+                    ItemName = itemName,
+                    PlayerName = playerName
+                });
+            }
+        }
+
+        private void Update()
+        {
+            float now = Time.realtimeSinceStartup;
+
+            lock (PendingLock)
+            {
+                while (PendingPopups.Count > 0)
+                {
+                    if (activePopups.Count >= MaxVisiblePopups)
+                        activePopups.RemoveAt(0);
+
+                    activePopups.Add(new ActivePopup
+                    {
+                        Data = PendingPopups.Dequeue(),
+                        CreatedAt = now
+                    });
+                }
+            }
+
+            activePopups.RemoveAll(popup => now - popup.CreatedAt >= DisplayDuration);
+        }
+
+        private void OnGUI()
+        {
+            if (activePopups.Count == 0) return;
+            EnsureStyles();
+
+            float width = Mathf.Min(PopupWidth, Screen.width - ScreenMargin * 2f);
+            float x = Screen.width - width - ScreenMargin;
+            float now = Time.realtimeSinceStartup;
+
+            for (int i = 0; i < activePopups.Count; i++)
+            {
+                ActivePopup popup = activePopups[i];
+                float age = now - popup.CreatedAt;
+                float fade = age > DisplayDuration - FadeDuration
+                    ? Mathf.Clamp01((DisplayDuration - age) / FadeDuration)
+                    : 1f;
+                float slide = Mathf.SmoothStep(22f, 0f, Mathf.Clamp01(age / 0.25f));
+                float y = ScreenMargin + i * (PopupHeight + PopupGap) - slide;
+                Rect popupRect = new Rect(x, y, width, PopupHeight);
+
+                GUI.color = new UnityColor(0f, 0f, 0f, 0.82f * fade);
+                GUI.DrawTexture(popupRect, backgroundTexture);
+
+                UnityColor accent = popup.Data.Direction == TransferDirection.Sent
+                    ? new UnityColor(0.25f, 0.65f, 1f, fade)
+                    : new UnityColor(0.3f, 0.9f, 0.45f, fade);
+                GUI.color = accent;
+                GUI.DrawTexture(new Rect(popupRect.x, popupRect.y, 5f, popupRect.height), accentTexture);
+
+                if (archipelagoIcon != null)
+                {
+                    GUI.color = new UnityColor(1f, 1f, 1f, fade);
+                    GUI.DrawTexture(
+                        new Rect(popupRect.x + 14f, popupRect.y + 10f, 38f, 38f),
+                        archipelagoIcon,
+                        ScaleMode.ScaleToFit,
+                        true);
+                }
+
+                string verb = popup.Data.Direction == TransferDirection.Sent ? "Sent" : "Received";
+                string preposition = popup.Data.Direction == TransferDirection.Sent ? "to" : "from";
+                string text = $"{verb} <b>{EscapeRichText(popup.Data.ItemName)}</b> {preposition} <b>{EscapeRichText(popup.Data.PlayerName)}</b>";
+
+                messageStyle.normal.textColor = new UnityColor(1f, 1f, 1f, fade);
+                float textX = archipelagoIcon != null ? popupRect.x + 63f : popupRect.x + 17f;
+                GUI.Label(new Rect(textX, popupRect.y + 6f, popupRect.xMax - textX - 12f, popupRect.height - 12f), text, messageStyle);
+            }
+
+            GUI.color = UnityColor.white;
+        }
+
+        private void EnsureStyles()
+        {
+            if (messageStyle == null)
+            {
+                messageStyle = new GUIStyle(GUI.skin.label)
+                {
+                    alignment = TextAnchor.MiddleLeft,
+                    fontSize = 16,
+                    richText = true,
+                    wordWrap = true
+                };
+            }
+
+            if (backgroundTexture == null)
+            {
+                backgroundTexture = new Texture2D(1, 1);
+                backgroundTexture.SetPixel(0, 0, UnityColor.white);
+                backgroundTexture.Apply();
+            }
+
+            if (accentTexture == null)
+            {
+                accentTexture = new Texture2D(1, 1);
+                accentTexture.SetPixel(0, 0, UnityColor.white);
+                accentTexture.Apply();
+            }
+
+            if (archipelagoIcon == null && Mod.Bundle != null)
+            {
+                archipelagoIcon = Mod.Bundle.LoadAsset<Texture2D>("Archipelago");
+                if (archipelagoIcon == null)
+                {
+                    Sprite iconSprite = Mod.Bundle.LoadAsset<Sprite>("Archipelago");
+                    archipelagoIcon = iconSprite?.texture;
+                }
+
+                if (archipelagoIcon == null)
+                {
+                    GameObject pedestalPrefab = Mod.Bundle.LoadAsset<GameObject>("ArchipelagoPedestal");
+                    if (pedestalPrefab != null)
+                    {
+                        Renderer[] renderers = pedestalPrefab.GetComponentsInChildren<Renderer>(true);
+                        foreach (Renderer renderer in renderers)
+                        {
+                            Texture2D texture = renderer.sharedMaterial?.mainTexture as Texture2D;
+                            if (texture == null) continue;
+
+                            archipelagoIcon = texture;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string EscapeRichText(string text)
+        {
+            return (text ?? string.Empty)
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;");
+        }
+
+        private void OnDestroy()
+        {
+            if (backgroundTexture != null) Destroy(backgroundTexture);
+            if (accentTexture != null) Destroy(accentTexture);
+        }
+    }
+}


### PR DESCRIPTION
Currently all the checks happen in the text box in the bottom right.

This obviously works and is OK, but I've seen a few other games like Celeste, or Bloons, that have small pop-ups when you send or receive a check instead.

I have added that here. No obligation if you don't this is a useful feature, but thought it looked a little nicer and it was easy enough to borrow from other code to make it happen.