### PR TITLE
Tweak `reach_day_x_with_dishesto register when day goal is greater than 15

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -187,9 +187,11 @@ namespace KitchenPlateupAP
         private static int goal = 0;             // 0 = franchise_x_times, 1 = complete_x_days, 2 = reach_day_x_with_dishes
         private static int franchiseCount = 0;   // how many times to franchise
         private static int dayCount = 1;        // how many days to complete
-        private static int dayTarget = 15;       // goal 2: global day the player must survive to (15–30)
+        private static int dayTarget = 15;       // goal 2: game day the player must survive to (including overtime)
         private static int dishGoalCount = 3;    // goal 2: number of dishes that must be active on that day
         private static List<string> selectedDishes = new List<string>();
+        private static readonly HashSet<string> completedGoalDishes =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static bool dishesMessageSent = false;
         private bool itemsQueuedThisLobby = false;
         int itemsKeptPerRun = 5;
@@ -934,7 +936,7 @@ namespace KitchenPlateupAP
 
                 if (slotData.TryGetValue("day_target", out object rawDayTarget))
                 {
-                    dayTarget = Mathf.Clamp(Convert.ToInt32(rawDayTarget), 15, 30);
+                    dayTarget = Mathf.Clamp(Convert.ToInt32(rawDayTarget), 15, 100);
                     Logger.LogInfo($"[PlateupAP] Day target (goal 2): {dayTarget}");
                 }
 
@@ -1640,6 +1642,7 @@ namespace KitchenPlateupAP
                 ReapplyMoneyCapFromHistory();
                 Logger.LogInfo("[Archipelago] Re-processing all previously received location checks");
                 ReconstructProgressFromLocationChecks();
+                LoadDishGoalProgress();
                 EnsureDishLockingBaseline();
                 ApplyGroupSizeOverride();
 
@@ -3703,7 +3706,9 @@ namespace KitchenPlateupAP
                 {
                     // Always run dish/setting checks first so their locations are
                     // in AllLocationsChecked before the goal condition is evaluated.
-                    if (lastDay <= dayTarget)
+                    // AP dish and setting locations intentionally stop at Day 15.
+                    // Overtime goal completion is tracked separately below.
+                    if (lastDay <= Mathf.Min(dayTarget, 15))
                     {
                         DoDishChecks(lastDay);
                         DoSettingChecks(lastDay);
@@ -3746,6 +3751,7 @@ namespace KitchenPlateupAP
                     // whether the day-counter location was new this frame.
                     if (gameDay >= dayTarget)
                     {
+                        RecordDishGoalCompletion(DishId, gameDay);
                         int dishesAtTarget = CountDishesCompletedAtDayTarget();
                         Logger.LogInfo($"[Dish Day Goal] Reached day_target={dayTarget}. Dishes at day {dayTarget}: {dishesAtTarget}, required: {dishGoalCount}");
                         if (dishesAtTarget >= dishGoalCount)
@@ -4659,29 +4665,93 @@ namespace KitchenPlateupAP
             Logger.LogInfo($"[ShopExpansion] Spawned {toSpawn} extra blueprint(s) this prep.");
         }
 
+        internal static bool IsDishCompletedForGoal2(string dishName)
+        {
+            if (goal != 2 || string.IsNullOrWhiteSpace(dishName))
+                return false;
+
+            return completedGoalDishes.Contains(dishName);
+        }
+
+        private void LoadDishGoalProgress()
+        {
+            completedGoalDishes.Clear();
+            if (goal != 2 || currentIdentity == null)
+                return;
+
+            var selectedSet = new HashSet<string>(selectedDishes, StringComparer.OrdinalIgnoreCase);
+            var state = PersistenceManager.LoadDishGoalProgress(currentIdentity);
+            bool compatibleState = state != null
+                && state.DayTarget == dayTarget
+                && new HashSet<string>(state.SelectedDishes ?? new List<string>(), StringComparer.OrdinalIgnoreCase)
+                    .SetEquals(selectedSet);
+
+            if (compatibleState)
+            {
+                foreach (string dishName in state.CompletedDishes ?? new List<string>())
+                {
+                    if (selectedSet.Contains(dishName))
+                        completedGoalDishes.Add(dishName);
+                }
+            }
+            else if (state != null)
+            {
+                Logger.LogInfo("[Dish Day Goal] Ignoring persisted dish progress because the target or selected dishes changed.");
+            }
+
+            Logger.LogInfo($"[Dish Day Goal] Restored {completedGoalDishes.Count} completed target-day dish(es) for Day {dayTarget}: {string.Join(", ", completedGoalDishes)}");
+        }
+
+        private static void SaveDishGoalProgress()
+        {
+            if (currentIdentity == null)
+                return;
+
+            var state = new DishGoalProgressState
+            {
+                DayTarget = dayTarget,
+                SelectedDishes = selectedDishes.ToList(),
+                CompletedDishes = selectedDishes
+                    .Where(completedGoalDishes.Contains)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+            };
+            PersistenceManager.SaveDishGoalProgress(currentIdentity, state);
+        }
+
+        private void RecordDishGoalCompletion(int dishGdoId, int gameDay)
+        {
+            if (goal != 2 || gameDay < dayTarget)
+                return;
+            if (!ProgressionMapping.dishDictionary.TryGetValue(dishGdoId, out string dishName))
+            {
+                Logger.LogWarning($"[Dish Day Goal] Reached Day {gameDay}, but active DishId {dishGdoId} could not be resolved.");
+                return;
+            }
+            if (!selectedDishes.Contains(dishName, StringComparer.OrdinalIgnoreCase))
+            {
+                Logger.LogWarning($"[Dish Day Goal] Reached Day {gameDay} with '{dishName}', but it is not one of this slot's selected dishes.");
+                return;
+            }
+
+            if (completedGoalDishes.Add(dishName))
+            {
+                SaveDishGoalProgress();
+                Logger.LogInfo($"[Dish Day Goal] Recorded '{dishName}' as reaching target Day {dayTarget}. Progress: {completedGoalDishes.Count}/{dishGoalCount}.");
+                CheckPopupManager.AddGoalDayCompleted(dishName, dayTarget);
+            }
+        }
+
         /// <summary>
-        /// Goal 2: Counts how many dishes from selected_dishes have a completed day check
-        /// at exactly day_target in AllLocationsChecked.
+        /// Goal 2: Counts selected dishes that have reached day_target. Day 16+
+        /// progress comes from persisted runtime detection because AP dish checks
+        /// intentionally stop at Day 15.
         /// </summary>
         private int CountDishesCompletedAtDayTarget()
         {
-            if (session?.Locations?.AllLocationsChecked == null)
-                return 0;
-
-            var checkedLocations = session.Locations.AllLocationsChecked;
-            int count = 0;
-
-            foreach (var dishName in selectedDishes)
-            {
-                if (!ProgressionMapping.dish_id_lookup.TryGetValue(dishName, out int dishId))
-                    continue;
-
-                int targetLocId = (dishId * 10000) + dayTarget;
-                if (checkedLocations.Contains(targetLocId))
-                    count++;
-            }
-
-            return count;
+            return selectedDishes
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count(IsDishCompletedForGoal2);
         }
     }
 }

--- a/Persistence/PersistenceManager.cs
+++ b/Persistence/PersistenceManager.cs
@@ -39,6 +39,17 @@ namespace KitchenPlateupAP
         public Dictionary<int, int> DishDayCounts = new Dictionary<int, int>();
     }
 
+    // Tracks which selected dishes have reached the configured goal day.
+    // Dish checks only exist through Day 15, so overtime goal progress needs
+    // its own persisted state instead of relying on AllLocationsChecked.
+    [Serializable]
+    public class DishGoalProgressState
+    {
+        public int DayTarget;
+        public List<string> SelectedDishes = new List<string>();
+        public List<string> CompletedDishes = new List<string>();
+    }
+
     // Represents identity of a run / server connection used to decide reset.
     [Serializable]
     public class RunIdentity
@@ -114,6 +125,8 @@ namespace KitchenPlateupAP
             Path.Combine(RootPath, $"trapcards_{Sanitize(id.Address)}_{id.Port}_{Sanitize(id.Player)}.json");
         private static string DishDayFile(RunIdentity id) =>
             Path.Combine(RootPath, $"dishdays_{Sanitize(id.Address)}_{id.Port}_{Sanitize(id.Player)}.json");
+        private static string DishGoalProgressFile(RunIdentity id) =>
+            Path.Combine(RootPath, $"dishgoal_{Sanitize(id.Address)}_{id.Port}_{Sanitize(id.Player)}.json");
         private static string IdentityFile => Path.Combine(RootPath, "last_identity.json");
         private static string GarageFile(RunIdentity id) =>
             Path.Combine(RootPath, $"garage_{Sanitize(id.Address)}_{id.Port}_{Sanitize(id.Player)}.json");
@@ -257,6 +270,36 @@ namespace KitchenPlateupAP
             }
         }
 
+        public static DishGoalProgressState LoadDishGoalProgress(RunIdentity id)
+        {
+            EnsureDirectory();
+            var path = DishGoalProgressFile(id);
+            if (!File.Exists(path))
+                return null;
+            try
+            {
+                return JsonConvert.DeserializeObject<DishGoalProgressState>(File.ReadAllText(path));
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[PlateupAP][Persistence] Failed reading dish goal progress: " + ex.Message);
+                return null;
+            }
+        }
+
+        public static void SaveDishGoalProgress(RunIdentity id, DishGoalProgressState state)
+        {
+            EnsureDirectory();
+            try
+            {
+                File.WriteAllText(DishGoalProgressFile(id), JsonConvert.SerializeObject(state, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[PlateupAP][Persistence] Failed saving dish goal progress: " + ex.Message);
+            }
+        }
+
         public static FranchiseProgressState LoadFranchiseProgress(RunIdentity id)
         {
             EnsureDirectory();
@@ -289,18 +332,20 @@ namespace KitchenPlateupAP
 
         public static void ResetForNewRun(RunIdentity id)
         {
-            // Delete speed + pending + trap card + dish day files for new identity
+            // Delete run-scoped state files for the new identity.
             try
             {
                 var speed = SpeedFile(id);
                 var pending = PendingFile(id);
                 var trapCards = TrapCardFile(id);
                 var dishDays = DishDayFile(id);
+                var dishGoalProgress = DishGoalProgressFile(id);
                 var blueprintChecks = BlueprintCheckFile(id);
                 if (File.Exists(speed)) File.Delete(speed);
                 if (File.Exists(pending)) File.Delete(pending);
                 if (File.Exists(trapCards)) File.Delete(trapCards);
                 if (File.Exists(dishDays)) File.Delete(dishDays);
+                if (File.Exists(dishGoalProgress)) File.Delete(dishGoalProgress);
                 if (File.Exists(blueprintChecks)) File.Delete(blueprintChecks);
             }
             catch (Exception ex)

--- a/UI/Chat.cs
+++ b/UI/Chat.cs
@@ -642,17 +642,12 @@ namespace KitchenPlateupAP
         }
 
         /// <summary>
-        /// Returns true when goal == 2 and the dish has a checked location at dayTarget,
-        /// meaning the player survived to the target day while this dish was active.
+        /// Returns true when goal == 2 and the dish has reached dayTarget.
+        /// Completion is restored from the mod's persisted goal state.
         /// </summary>
         private static bool IsDishCompletedForGoal2(string dishName)
         {
-            if (Mod.Goal != 2) return false;
-            var session = ArchipelagoConnectionManager.Session;
-            if (session?.Locations?.AllLocationsChecked == null) return false;
-            if (!ProgressionMapping.dish_id_lookup.TryGetValue(dishName, out int dishId)) return false;
-            int targetLocId = (dishId * 10000) + Mod.DayTarget;
-            return session.Locations.AllLocationsChecked.Contains(targetLocId);
+            return Mod.IsDishCompletedForGoal2(dishName);
         }
 
         private void DrawGlobalFooterHUD(float opacity, Rect footerRect)

--- a/UI/CheckPopupManager.cs
+++ b/UI/CheckPopupManager.cs
@@ -24,6 +24,7 @@ namespace KitchenPlateupAP
             public TransferDirection Direction;
             public string ItemName;
             public string PlayerName;
+            public string DisplayText;
         }
 
         private class ActivePopup
@@ -67,6 +68,18 @@ namespace KitchenPlateupAP
                     TransferDirection.Received,
                     GetItemName(transfer.Item),
                     GetPlayerName(transfer.Sender));
+            }
+        }
+
+        public static void AddGoalDayCompleted(string dishName, int dayTarget)
+        {
+            lock (PendingLock)
+            {
+                PendingPopups.Enqueue(new PendingPopup
+                {
+                    Direction = TransferDirection.Sent,
+                    DisplayText = $"Completed <b>{EscapeRichText(dishName)}</b> — Day <b>{dayTarget}</b> goal reached"
+                });
             }
         }
 
@@ -159,9 +172,13 @@ namespace KitchenPlateupAP
                         true);
                 }
 
-                string verb = popup.Data.Direction == TransferDirection.Sent ? "Sent" : "Received";
-                string preposition = popup.Data.Direction == TransferDirection.Sent ? "to" : "from";
-                string text = $"{verb} <b>{EscapeRichText(popup.Data.ItemName)}</b> {preposition} <b>{EscapeRichText(popup.Data.PlayerName)}</b>";
+                string text = popup.Data.DisplayText;
+                if (string.IsNullOrEmpty(text))
+                {
+                    string verb = popup.Data.Direction == TransferDirection.Sent ? "Sent" : "Received";
+                    string preposition = popup.Data.Direction == TransferDirection.Sent ? "to" : "from";
+                    text = $"{verb} <b>{EscapeRichText(popup.Data.ItemName)}</b> {preposition} <b>{EscapeRichText(popup.Data.PlayerName)}</b>";
+                }
 
                 messageStyle.normal.textColor = new UnityColor(1f, 1f, 1f, fade);
                 float textX = archipelagoIcon != null ? popupRect.x + 63f : popupRect.x + 17f;


### PR DESCRIPTION
The `reach_day_x_with_dishes` option currently listens to the "Day X - <Dish>" checks. This is fine as long as the YAML option is less than 15.

I have changed the system to count the day and log it in the persistent storage for the seed.

**Warning**: Current seeds will _not_ retain their progress under this system. I decided not to add a legacy fallback for this as the number of long term seeds is probably small. If you think it would be useful I can put it back in.
Existing seeds will need to re-play any dishes if they have this goal to trigger completion.

The other goal methods are not changed.